### PR TITLE
Packages upgrade

### DIFF
--- a/FakePOS.sln
+++ b/FakePOS.sln
@@ -39,6 +39,7 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E881120C-79A7-4298-BFB0-9CD2AD891D56}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{E881120C-79A7-4298-BFB0-9CD2AD891D56}.Debug|Any CPU.Build.0 = Debug|x86
 		{E881120C-79A7-4298-BFB0-9CD2AD891D56}.Debug|ARM.ActiveCfg = Debug|x86
 		{E881120C-79A7-4298-BFB0-9CD2AD891D56}.Debug|arm64.ActiveCfg = Debug|arm64
 		{E881120C-79A7-4298-BFB0-9CD2AD891D56}.Debug|arm64.Build.0 = Debug|arm64
@@ -61,6 +62,7 @@ Global
 		{E881120C-79A7-4298-BFB0-9CD2AD891D56}.Release|x86.Build.0 = Release|x86
 		{E881120C-79A7-4298-BFB0-9CD2AD891D56}.Release|x86.Deploy.0 = Release|x86
 		{5862C93F-A97C-494F-AFB1-5D8AE958F54A}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{5862C93F-A97C-494F-AFB1-5D8AE958F54A}.Debug|Any CPU.Build.0 = Debug|x86
 		{5862C93F-A97C-494F-AFB1-5D8AE958F54A}.Debug|ARM.ActiveCfg = Debug|x86
 		{5862C93F-A97C-494F-AFB1-5D8AE958F54A}.Debug|arm64.ActiveCfg = Debug|arm64
 		{5862C93F-A97C-494F-AFB1-5D8AE958F54A}.Debug|arm64.Build.0 = Debug|arm64

--- a/FakePOS/FakePOS.Models/FakePOS.Models.csproj
+++ b/FakePOS/FakePOS.Models/FakePOS.Models.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="8.0.0-preview5" />
+    <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/FakePOS/FakePOS.Services/FakePOS.Services.csproj
+++ b/FakePOS/FakePOS.Services/FakePOS.Services.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="8.0.0-preview5" />
+    <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.1.2" />
   </ItemGroup>
 
 </Project>

--- a/FakePOS/FakePOS.ViewModels/FakePOS.ViewModels.csproj
+++ b/FakePOS/FakePOS.ViewModels/FakePOS.ViewModels.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="8.0.0-preview5" />
+    <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FakePOS/FakePOS.WinUI.Services/FakePOS.WinUI.Services.csproj
+++ b/FakePOS/FakePOS.WinUI.Services/FakePOS.WinUI.Services.csproj
@@ -15,9 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Toolkit.Diagnostics" Version="7.0.0" />
-    <PackageReference Include="Microsoft.ProjectReunion" Version="0.5.0-prerelease" />
-      <PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="0.5.0-prerelease" />
-      <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="0.5.0-prerelease" />
+    <PackageReference Include="Microsoft.ProjectReunion" Version="0.8.6" />
+      <PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="0.8.6" />
+      <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="0.8.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FakePOS/FakePOSuwp/FakePOSuwp.csproj
+++ b/FakePOS/FakePOSuwp/FakePOSuwp.csproj
@@ -380,13 +380,13 @@
       <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Mvvm">
-      <Version>8.0.0-preview5</Version>
+      <Version>7.1.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Animations">
-      <Version>7.0.0-preview5</Version>
+      <Version>7.1.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>7.0.0-preview5</Version>
+      <Version>7.1.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.6.0-prerelease.210217002</Version>

--- a/FakePOS/FakePOSuwp/Styles/Converters.xaml
+++ b/FakePOS/FakePOSuwp/Styles/Converters.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters">
+    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters">
 
     <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" FalseValue="Collapsed" TrueValue="Visible" />
     <converters:BoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter" FalseValue="Visible" TrueValue="Collapsed" />

--- a/FakePOS/FakePOSuwp/ViewModels/Catalog/ItemsListViewModel.cs
+++ b/FakePOS/FakePOSuwp/ViewModels/Catalog/ItemsListViewModel.cs
@@ -12,9 +12,9 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 #endif
 
+using CommunityToolkit.WinUI.UI.Controls;
 using Microsoft.Toolkit.Mvvm.Input;
 using Microsoft.Toolkit.Mvvm.Messaging;
-using Microsoft.Toolkit.Uwp.UI.Controls;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 

--- a/FakePOS/FakePOSuwp/Views/Catalog/ItemDetail/RelatedItems.xaml
+++ b/FakePOS/FakePOSuwp/Views/Catalog/ItemDetail/RelatedItems.xaml
@@ -2,7 +2,7 @@
     x:Class="FakePOS.Views.RelatedItems"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:toolkit="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:local="using:FakePOS.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/FakePOS/FakePOSuwp/Views/Catalog/ItemsGridView.xaml
+++ b/FakePOS/FakePOSuwp/Views/Catalog/ItemsGridView.xaml
@@ -6,8 +6,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:i="using:Microsoft.Xaml.Interactivity"
              xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-             xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
-             xmlns:animations="using:Microsoft.Toolkit.Uwp.UI.Animations"
+             xmlns:toolkit="using:CommunityToolkit.WinUI.UI.Controls"
              mc:Ignorable="d">
     <UserControl.Resources>
         <DataTemplate x:Key="BottomItem">

--- a/FakePOS/FakePOSuwp/Views/Catalog/ItemsListView.xaml
+++ b/FakePOS/FakePOSuwp/Views/Catalog/ItemsListView.xaml
@@ -5,7 +5,7 @@
     xmlns:local="using:FakePOS.Views"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-    xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:toolkit="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"

--- a/FakePOS/FakePOSwinui (Package)/FakePOSwinui (Package).wapproj
+++ b/FakePOS/FakePOSwinui (Package)/FakePOSwinui (Package).wapproj
@@ -66,19 +66,19 @@
     <!--PackageReference.GeneratePathProperty does not support NUGET_PACKAGES env var...-->
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)'==''">$(NUGET_PACKAGES)</NuGetPackageRoot>
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)'==''">$(UserProfile)\.nuget\packages</NuGetPackageRoot>
-    <PkgMicrosoft_ProjectReunion Condition="'$(PkgMicrosoft_ProjectReunion)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion', '0.5.0-prerelease'))</PkgMicrosoft_ProjectReunion>
-    <PkgMicrosoft_ProjectReunion Condition="!Exists($(PkgMicrosoft_ProjectReunion))">$(SolutionDir)packages\Microsoft.ProjectReunion.0.5.0-prerelease\</PkgMicrosoft_ProjectReunion>
-    <PkgMicrosoft_ProjectReunion_WinUI Condition="'$(PkgMicrosoft_ProjectReunion_WinUI)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion.WinUI', '0.5.0-prerelease'))</PkgMicrosoft_ProjectReunion_WinUI>
-    <PkgMicrosoft_ProjectReunion_WinUI Condition="!Exists($(PkgMicrosoft_ProjectReunion_WinUI))">$(SolutionDir)packages\Microsoft.ProjectReunion.WinUI.0.5.0-prerelease\</PkgMicrosoft_ProjectReunion_WinUI>
+    <PkgMicrosoft_ProjectReunion Condition="'$(PkgMicrosoft_ProjectReunion)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion', '0.8.6'))</PkgMicrosoft_ProjectReunion>
+    <PkgMicrosoft_ProjectReunion Condition="!Exists($(PkgMicrosoft_ProjectReunion))">$(SolutionDir)packages\Microsoft.ProjectReunion.0.8.6\</PkgMicrosoft_ProjectReunion>
+    <PkgMicrosoft_ProjectReunion_WinUI Condition="'$(PkgMicrosoft_ProjectReunion_WinUI)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion.WinUI', '0.8.6'))</PkgMicrosoft_ProjectReunion_WinUI>
+    <PkgMicrosoft_ProjectReunion_WinUI Condition="!Exists($(PkgMicrosoft_ProjectReunion_WinUI))">$(SolutionDir)packages\Microsoft.ProjectReunion.WinUI.0.8.6\</PkgMicrosoft_ProjectReunion_WinUI>
     <Microsoft_ProjectReunion_AppXReference_props>$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_ProjectReunion)', 'build'))Microsoft.ProjectReunion.AppXReference.props</Microsoft_ProjectReunion_AppXReference_props>
     <Microsoft_WinUI_AppX_targets>$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_ProjectReunion_WinUI)', 'build'))Microsoft.WinUI.AppX.targets</Microsoft_WinUI_AppX_targets>
     <EntryPointProjectUniqueName>..\FakePOSwinui\FakePOSwinui.csproj</EntryPointProjectUniqueName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ProjectReunion" Version="[0.5.0-prerelease]" GeneratePathProperty="true">
+    <PackageReference Include="Microsoft.ProjectReunion" Version="[0.8.6]" GeneratePathProperty="true">
       <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="[0.5.0-prerelease]" GeneratePathProperty="true">
+    <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="[0.8.6]" GeneratePathProperty="true">
       <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/FakePOS/FakePOSwinui/App.xaml.cs
+++ b/FakePOS/FakePOSwinui/App.xaml.cs
@@ -32,7 +32,9 @@ namespace FakePOS
         public App()
         {
             this.InitializeComponent();
-            this.Suspending += OnSuspending;
+
+            // LT! Error CS1061 'App' does not contain a definition for 'Suspending' and no accessible extension method 'Suspending' accepting a first argument of type 'App' could be found
+            //this.Suspending += OnSuspending;
 
             var assembly = (typeof(App)).GetTypeInfo().Assembly;
             AppVersion = assembly.GetName().Version.ToString();

--- a/FakePOS/FakePOSwinui/FakePOSwinui.csproj
+++ b/FakePOS/FakePOSwinui/FakePOSwinui.csproj
@@ -138,8 +138,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.1.2" />
-    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="7.1.2" />
-    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.DataGrid" Version="7.1.2" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.0.3" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.0.3" />
     <PackageReference Include="Microsoft.ProjectReunion" Version="0.8.6" />
     <PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="0.8.6" />
     <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="0.8.6" />

--- a/FakePOS/FakePOSwinui/FakePOSwinui.csproj
+++ b/FakePOS/FakePOSwinui/FakePOSwinui.csproj
@@ -137,12 +137,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="8.0.0-preview5" />
-    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="8.0.0-preview5" />
-    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.DataGrid" Version="8.0.0-preview5" />
-    <PackageReference Include="Microsoft.ProjectReunion" Version="0.5.0-prerelease" />
-    <PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="0.5.0-prerelease" />
-    <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="0.5.0-prerelease" />
+    <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.1.2" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="7.1.2" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.DataGrid" Version="7.1.2" />
+    <PackageReference Include="Microsoft.ProjectReunion" Version="0.8.6" />
+    <PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="0.8.6" />
+    <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="0.8.6" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.3-rc6" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>


### PR DESCRIPTION
This PR contains:
- Upgraded versions of NuGet packages.
- Updated namespaces.

There is one build issue: 
MSB4044 The "ReplaceMUXWinRTRegistrations" task was not given a value for the required parameter "WinUIAssemblies". FakePOSwinui (Package)	\.nuget\packages\microsoft.projectreunion.winui\0.8.6\build\Microsoft.WinUI.AppX.targets
